### PR TITLE
Update rtnetlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.1]
 
 ### Fixed
 - Update to `rtnetlink` `v0.10`. See [PR 19].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Update to `rtnetlink` `v0.10`. See [PR 19].
+
+[PR 19]: https://github.com/mxinden/if-watch/pull/19
+
 ## [1.1.0]
 ### Added
 - Return socket closure as error. See [PR 15].

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "if-watch"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies Limited <admin@parity.io>"]
 edition = "2021"
 keywords = ["asynchronous", "routing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ipnet = "2.3.1"
 log = "0.4.14"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = { version = "0.9.0", default-features = false, features = ["smol_socket"] }
+rtnetlink = { version = "0.10.0", default-features = false, features = ["smol_socket"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.9.2"


### PR DESCRIPTION
Currently, the CI workflow on Linux fails.

https://github.com/ackintosh/if-watch/runs/7024984543?check_suite_focus=true
>    Compiling rtnetlink v0.9.1
> error[E0432]: unresolved import `netlink_proto::ErrorKind`
> Error:   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rtnetlink-0.9.1/src/lib.rs:47:9
>    |
> 47 |         ErrorKind,
>    |         ^^^^^^^^^ no `ErrorKind` in the root

From what I've seen, it is due to incompatibility in `netlink-proto v0.9.3`, which is a dependency of `rtnetlink v0.9`. [`ErrorKind` is removed in `netlink-proto v0.9.3`](https://github.com/little-dude/netlink/commit/3d799dfb94f29c32a4b80596dacc8e8cb5ee540c#diff-b0d5b1117b5db4d8183699695c59e839c5b78e5d1c22117702287b1ecd2e66af) but `rtnetlink v0.9` is still using it.

The issue above can be solved by updating rtnetlink from v0.9 to v0.10.

Release note on `netlink`: https://github.com/little-dude/netlink/releases/tag/20220623
