### PR TITLE
*:  Add `IfWatcher::poll_if_event` instead of `IfWatcher::poll_next`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] [Unreleased]
 
 ### Changed
-- Add `IfWatcher::poll_next`. Implement `Stream` instead of `Future` for `IfWatcher`. See [PR 23].
+- Add `IfWatcher::poll_if_event`. Implement `Stream` instead of `Future` for `IfWatcher`.
+  See [PR 23] and [PR 25].
 - Make `IfWatcher::new` synchronous. See [PR 24].
 
 [PR 23]: https://github.com/mxinden/if-watch/pull/23
 [PR 24]: https://github.com/mxinden/if-watch/pull/24
+[PR 25]: https://github.com/mxinden/if-watch/pull/25
 
 ## [1.1.1]
 

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -59,7 +59,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -59,7 +59,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -49,7 +49,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -49,7 +49,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl IfWatcher {
     }
 
     /// Poll for an address change event.
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         Pin::new(&mut self.0).poll_next(cx)
     }
 }
@@ -74,7 +74,7 @@ impl IfWatcher {
 impl Stream for IfWatcher {
     type Item = Result<IfEvent>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.poll_next(cx).map(Some)
+        Pin::into_inner(self).poll_next(cx).map(Some)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl IfWatcher {
 
     /// Poll for an address change event.
     pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
-        Pin::new(&mut self.0).poll_next(cx)
+        self.0.poll_next(cx)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,15 +66,15 @@ impl IfWatcher {
     }
 
     /// Poll for an address change event.
-    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
-        self.0.poll_next(cx)
+    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
+        self.0.poll_if_event(cx)
     }
 }
 
 impl Stream for IfWatcher {
     type Item = Result<IfEvent>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::into_inner(self).poll_next(cx).map(Some)
+        Pin::into_inner(self).poll_if_event(cx).map(Some)
     }
 }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -80,7 +80,7 @@ impl IfWatcher {
         }
     }
 
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -80,7 +80,7 @@ impl IfWatcher {
         }
     }
 
-    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/win.rs
+++ b/src/win.rs
@@ -67,7 +67,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));

--- a/src/win.rs
+++ b/src/win.rs
@@ -5,7 +5,6 @@ use if_addrs::IfAddr;
 use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::io::{Error, ErrorKind, Result};
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/src/win.rs
+++ b/src/win.rs
@@ -68,7 +68,7 @@ impl IfWatcher {
         self.addrs.iter()
     }
 
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<IfEvent>> {
+    pub fn poll_next(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
                 return Poll::Ready(Ok(event));


### PR DESCRIPTION
Since `IfWatcher` is `Unpin` we can make `poll_next` take `&mut self` instead of `self: Pin<&mut Self>` and implement `Stream` by using `Pin::into_inner`.

Proposed by @thomaseizinger in https://github.com/libp2p/rust-libp2p/pull/2813#discussion_r943988736.
@thomaseizinger did I understand it correctly that this was the idea?

---

Also renamed `poll_next` to `poll_if_event` in e56e686 to avoid conflicting names with `<IfWatcher as Stream>::poll_next`. I don't feel strongly about that, happy to drop that commit it if folks prefer to stick with `poll_next`.