### PR TITLE
linux: Feature gate async runtime, allowing opting between Tokio or smol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Build android
       if: contains(matrix.platform.target, 'android')
-      run: cargo apk --target ${{ matrix.platform.target }} build --workspace --all-features
+      run: cargo apk build --target ${{ matrix.platform.target }} --all-features
 
     - name: Rust tests
       if: matrix.platform.cross == false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - [unreleased]
+
+### Added
+- Allow opting for Tokio instead of smol for the `AsyncSocket`. See [PR 27](https://github.com/mxinden/if-watch/pull/27).
+
 ## [2.0.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - [unreleased]
+## [3.0.0] - [unreleased]
 
-### Added
-- Allow opting for Tokio instead of smol for the `AsyncSocket`. See [PR 27](https://github.com/mxinden/if-watch/pull/27).
+### Changed
+- Feature gate async runtime, allowing opting between Tokio or smol. For every OS each `IfWatcher` is
+  under the `tokio` or `smol` module. This makes it a breaking change as there
+  is no more a default implementation. See [PR 27](https://github.com/mxinden/if-watch/pull/27).
 
 ## [2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - [unreleased]
+## [3.0.0]
 
 ### Changed
 - Feature gate async runtime, allowing opting between Tokio or smol. For every OS each `IfWatcher` is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "crossplatform asynchronous network watcher"
 repository = "https://github.com/mxinden/if-watch"
 
 [features]
-default = ["smol"]
 tokio = ["dep:tokio", "rtnetlink/tokio_socket"]
 smol = ["dep:smol", "rtnetlink/smol_socket"]
 
@@ -41,3 +40,8 @@ if-addrs = "0.7.0"
 env_logger = "0.9.0"
 smol = "1.2.5"
 tokio = { version = "1.21.2", features = ["rt", "macros"] }
+
+[[example]]
+name = "if_watch"
+required-features = ["smol"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "if-watch"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies Limited <admin@parity.io>"]
 edition = "2021"
 keywords = ["asynchronous", "routing"]
@@ -10,8 +10,8 @@ repository = "https://github.com/mxinden/if-watch"
 
 [features]
 default = ["smol"]
-tokio = ["rtnetlink/tokio_socket"]
-smol = ["rtnetlink/smol_socket"]
+tokio = ["dep:tokio", "rtnetlink/tokio_socket"]
+smol = ["dep:smol", "rtnetlink/smol_socket"]
 
 [dependencies]
 fnv = "1.0.7"
@@ -26,6 +26,8 @@ rtnetlink = { version = "0.10.0", default-features = false }
 core-foundation = "0.9.2"
 if-addrs = "0.7.0"
 system-configuration = "0.5.0"
+tokio = { version = "1.21.2", features = ["rt"], optional = true }
+smol = { version = "1.2.5", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 if-addrs = "0.7.0"
@@ -37,3 +39,5 @@ if-addrs = "0.7.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"
+smol = "1.2.5"
+tokio = { version = "1.21.2", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT OR Apache-2.0"
 description = "crossplatform asynchronous network watcher"
 repository = "https://github.com/mxinden/if-watch"
 
+[features]
+default = ["smol_socket"]
+tokio = ["rtnetlink/tokio_socket"]
+smol_socket = ["rtnetlink/smol_socket"]
+
 [dependencies]
 fnv = "1.0.7"
 futures = "0.3.19"
@@ -15,7 +20,7 @@ ipnet = "2.3.1"
 log = "0.4.14"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = { version = "0.10.0", default-features = false, features = ["smol_socket"] }
+rtnetlink = { version = "0.10.0", default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ description = "crossplatform asynchronous network watcher"
 repository = "https://github.com/mxinden/if-watch"
 
 [features]
-default = ["smol_socket"]
+default = ["smol"]
 tokio = ["rtnetlink/tokio_socket"]
-smol_socket = ["rtnetlink/smol_socket"]
+smol = ["rtnetlink/smol_socket"]
 
 [dependencies]
 fnv = "1.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 description = "crossplatform asynchronous network watcher"
 repository = "https://github.com/mxinden/if-watch"
 
+[lib]
+crate-type = ["cdylib", "lib"]
+
 [features]
 tokio = ["dep:tokio", "rtnetlink/tokio_socket"]
 smol = ["dep:smol", "rtnetlink/smol_socket"]

--- a/examples/if_watch.rs
+++ b/examples/if_watch.rs
@@ -1,9 +1,9 @@
 use futures::StreamExt;
-use if_watch::IfWatcher;
+use if_watch::smol::IfWatcher;
 
 fn main() {
     env_logger::init();
-    futures::executor::block_on(async {
+    smol::block_on(async {
         let mut set = IfWatcher::new().unwrap();
         loop {
             let event = set.select_next_some().await;

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -87,7 +87,7 @@ where
     /// Create a watcher.
     pub fn new() -> Result<Self> {
         let (tx, rx) = mpsc::channel(1);
-        T::spawn(async { background_task(tx) });
+        T::spawn(background_task(tx));
         let mut watcher = Self {
             addrs: Default::default(),
             queue: Default::default(),
@@ -183,7 +183,7 @@ fn callback(_store: SCDynamicStore, _changed_keys: CFArray<CFString>, info: &mut
     }
 }
 
-fn background_task(tx: mpsc::Sender<()>) {
+async fn background_task(tx: mpsc::Sender<()>) {
     let store = SCDynamicStoreBuilder::new("global-network-watcher")
         .callback_context(SCDynamicStoreCallBackContext {
             callout: callback,

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -4,7 +4,6 @@ use futures::stream::{FusedStream, Stream};
 use if_addrs::IfAddr;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::collections::{HashSet, VecDeque};
-use std::future::Future;
 use std::io::Result;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,6 +1,6 @@
 use crate::IfEvent;
 use async_io::Timer;
-use futures::stream::Stream;
+use futures::stream::{FusedStream, Stream};
 use if_addrs::IfAddr;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::collections::{HashSet, VecDeque};
@@ -9,6 +9,26 @@ use std::io::Result;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+
+#[cfg(feature = "tokio")]
+pub mod tokio {
+    //! An interface watcher.
+    //! **On this platform there is no difference between `tokio` and `smol` features,**
+    //! **this was done to maintain the api compatible with other platforms**.
+
+    /// Watches for interface changes.
+    pub type IfWatcher = super::IfWatcher;
+}
+
+#[cfg(feature = "smol")]
+pub mod smol {
+    //! An interface watcher.
+    //! **On this platform there is no difference between `tokio` and `smol` features,**
+    //! **this was done to maintain the api compatible with other platforms**.
+
+    /// Watches for interface changes.
+    pub type IfWatcher = super::IfWatcher;
+}
 
 /// An address set/watcher
 #[derive(Debug)]
@@ -19,7 +39,7 @@ pub struct IfWatcher {
 }
 
 impl IfWatcher {
-    /// Create a watcher
+    /// Create a watcher.
     pub fn new() -> Result<Self> {
         Ok(Self {
             addrs: Default::default(),
@@ -45,10 +65,12 @@ impl IfWatcher {
         Ok(())
     }
 
+    /// Iterate over current networks.
     pub fn iter(&self) -> impl Iterator<Item = &IpNet> {
         self.addrs.iter()
     }
 
+    /// Poll for an address change event.
     pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
         loop {
             if let Some(event) = self.queue.pop_front() {
@@ -61,6 +83,19 @@ impl IfWatcher {
                 return Poll::Ready(Err(err));
             }
         }
+    }
+}
+
+impl Stream for IfWatcher {
+    type Item = Result<IfEvent>;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::into_inner(self).poll_if_event(cx).map(Some)
+    }
+}
+
+impl FusedStream for IfWatcher {
+    fn is_terminated(&self) -> bool {
+        false
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,23 @@ pub use apple::tokio;
 #[cfg(feature = "smol")]
 pub use apple::smol;
 
-#[cfg(target_os = "ios")]
-use apple as platform_impl;
+#[cfg(feature = "smol")]
 #[cfg(not(any(
     target_os = "ios",
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
 )))]
-use fallback as platform_impl;
+pub use fallback::smol;
+
+#[cfg(feature = "tokio")]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+)))]
+pub use fallback::tokio;
 
 #[cfg(target_os = "windows")]
 #[cfg(feature = "tokio")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,12 @@ use fallback as platform_impl;
 use win as platform_impl;
 
 #[cfg(target_os = "linux")]
-#[cfg(feature = "tokio_socket")]
-pub use linux::TokioIfWatch;
+#[cfg(feature = "tokio")]
+pub use linux::tokio;
 
 #[cfg(target_os = "linux")]
-#[cfg(feature = "smol_socket")]
-pub use linux::SmolIfWatcher as IfWatcher;
+#[cfg(feature = "smol")]
+pub use linux::smol::IfWatcher;
 
 /// An address change event.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -100,8 +100,8 @@ impl FusedStream for IfWatcher {
 #[cfg(test)]
 mod tests {
     use super::IfWatcher;
-    use std::pin::Pin;
     use futures::StreamExt;
+    use std::pin::Pin;
 
     #[test]
     fn test_ip_watch() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-#[cfg(not(target_os = "linux"))]
-use futures::stream::{FusedStream, Stream};
 pub use ipnet::{IpNet, Ipv4Net, Ipv6Net};
-#[cfg(not(target_os = "linux"))]
-use std::{
-    io::Result,
-    pin::Pin,
-    task::{Context, Poll},
-};
 
 #[cfg(target_os = "macos")]
 mod apple;
@@ -28,8 +20,14 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod win;
 
-#[cfg(target_os = "macos")]
-use apple as platform_impl;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(feature = "tokio")]
+pub use apple::tokio;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(feature = "smol")]
+pub use apple::smol;
+
 #[cfg(target_os = "ios")]
 use apple as platform_impl;
 #[cfg(not(any(
@@ -39,8 +37,14 @@ use apple as platform_impl;
     target_os = "windows",
 )))]
 use fallback as platform_impl;
+
 #[cfg(target_os = "windows")]
-use win as platform_impl;
+#[cfg(feature = "tokio")]
+pub use win::tokio;
+
+#[cfg(target_os = "windows")]
+#[cfg(feature = "smol")]
+pub use win::smol;
 
 #[cfg(target_os = "linux")]
 #[cfg(feature = "tokio")]
@@ -48,7 +52,7 @@ pub use linux::tokio;
 
 #[cfg(target_os = "linux")]
 #[cfg(feature = "smol")]
-pub use linux::smol::IfWatcher;
+pub use linux::smol;
 
 /// An address change event.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -59,66 +63,50 @@ pub enum IfEvent {
     Down(IpNet),
 }
 
-/// Watches for interface changes.
-#[cfg(not(target_os = "linux"))]
-#[derive(Debug)]
-pub struct IfWatcher(platform_impl::IfWatcher);
-
-#[cfg(not(target_os = "linux"))]
-impl IfWatcher {
-    /// Create a watcher.
-    pub fn new() -> Result<Self> {
-        platform_impl::IfWatcher::new().map(Self)
-    }
-
-    /// Iterate over current networks.
-    pub fn iter(&self) -> impl Iterator<Item = &IpNet> {
-        self.0.iter()
-    }
-
-    /// Poll for an address change event.
-    pub fn poll_if_event(&mut self, cx: &mut Context) -> Poll<Result<IfEvent>> {
-        self.0.poll_if_event(cx)
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-impl Stream for IfWatcher {
-    type Item = Result<IfEvent>;
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::into_inner(self).poll_if_event(cx).map(Some)
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-impl FusedStream for IfWatcher {
-    fn is_terminated(&self) -> bool {
-        false
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::IfWatcher;
     use futures::StreamExt;
     use std::pin::Pin;
 
     #[test]
-    fn test_ip_watch() {
-        futures::executor::block_on(async {
+    fn test_smol_ip_watch() {
+        use super::smol::IfWatcher;
+
+        smol::block_on(async {
             let mut set = IfWatcher::new().unwrap();
             let event = set.select_next_some().await.unwrap();
             println!("Got event {:?}", event);
         });
     }
 
+    #[tokio::test]
+    async fn test_tokio_ip_watch() {
+        use super::tokio::IfWatcher;
+
+        let mut set = IfWatcher::new().unwrap();
+        let event = set.select_next_some().await.unwrap();
+        println!("Got event {:?}", event);
+    }
+
     #[test]
-    fn test_is_send() {
-        futures::executor::block_on(async {
+    fn test_smol_is_send() {
+        use super::smol::IfWatcher;
+
+        smol::block_on(async {
             fn is_send<T: Send>(_: T) {}
             is_send(IfWatcher::new());
             is_send(IfWatcher::new().unwrap());
             is_send(Pin::new(&mut IfWatcher::new().unwrap()));
         });
+    }
+
+    #[tokio::test]
+    async fn test_tokio_is_send() {
+        use super::tokio::IfWatcher;
+
+        fn is_send<T: Send>(_: T) {}
+        is_send(IfWatcher::new());
+        is_send(IfWatcher::new().unwrap());
+        is_send(Pin::new(&mut IfWatcher::new().unwrap()));
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -7,10 +7,6 @@ use rtnetlink::constants::{RTMGRP_IPV4_IFADDR, RTMGRP_IPV6_IFADDR};
 use rtnetlink::packet::address::nlas::Nla;
 use rtnetlink::packet::{AddressMessage, RtnlMessage};
 use rtnetlink::proto::{Connection, NetlinkPayload};
-#[cfg(feature = "smol_socket")]
-use rtnetlink::sys::SmolSocket;
-#[cfg(feature = "tokio_socket")]
-use rtnetlink::sys::TokioSocket;
 use rtnetlink::sys::{AsyncSocket, SocketAddr};
 use std::collections::VecDeque;
 use std::future::Future;
@@ -19,13 +15,23 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-#[cfg(feature = "tokio_socket")]
-/// Watches for interface changes.
-pub type TokioIfWatcher = IfWatcher<TokioSocket>;
+#[cfg(feature = "tokio")]
+pub mod tokio {
+    //! An interface watcher that uses `rtnetlink`'s [`TokioSocket`](rtnetlink::sys::TokioSocket)
+    use rtnetlink::sys::TokioSocket;
 
-#[cfg(feature = "smol_socket")]
-/// Watches for interface changes.
-pub type SmolIfWatcher = IfWatcher<SmolSocket>;
+    /// Watches for interface changes.
+    pub type IfWatcher = super::IfWatcher<TokioSocket>;
+}
+
+#[cfg(feature = "smol")]
+pub mod smol {
+    //! An interface watcher that uses `rtnetlink`'s [`SmolSocket`](rtnetlink::sys::SmolSocket)
+    use rtnetlink::sys::SmolSocket;
+
+    /// Watches for interface changes.
+    pub type IfWatcher = super::IfWatcher<SmolSocket>;
+}
 
 pub struct IfWatcher<T> {
     conn: Connection<RtnlMessage, T>,


### PR DESCRIPTION
Following #21 and confirming @dignifiedquire's https://github.com/mxinden/if-watch/issues/21#issuecomment-1191473237, we still [can't define features per target](https://github.com/rust-lang/cargo/issues/1197). 

But it seems we can define features for dependencies, and then dependencies can be defined per target.  
With that we can apply the similar technique [`rtnetlink` uses to support both runtimes](https://github.com/little-dude/netlink/blob/master/rtnetlink/src/ns.rs#L27), with the difference that in our case as `smol_socket` is the default (to maintain backwards compatibility) we invert the feature combination and if both are enabled `tokio` takes priority. 

Only downside that comes to mind with this approach is if someone uses `if-watch` with `default-features = false` crate compilation breaks (which is also the reason this change is technically a breaking change). We can use [`compile_error!`](https://doc.rust-lang.org/std/macro.compile_error.html) to give a better compilation error. 

CC @thomaseizinger
