### PR TITLE
Fix: fallback interface down/up logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+
+### Fixed
+
+- For all architectures running the fallback option (e.g. Android) reverse the logic when checking if a recorded interface still exists in the new list to avoid reporting all interfaces as down and then up in the same resync().
+  See [PR 31].
+
+[PR 31]: https://github.com/mxinden/if-watch/pull/31
+
 ## [3.0.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "if-watch"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies Limited <admin@parity.io>"]
 edition = "2021"
 keywords = ["asynchronous", "routing"]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -50,7 +50,7 @@ impl IfWatcher {
     fn resync(&mut self) -> Result<()> {
         let addrs = if_addrs::get_if_addrs()?;
         for old_addr in self.addrs.clone() {
-            if addrs.iter().any(|addr| addr.ip() == old_addr.addr()) {
+            if !addrs.iter().any(|addr| addr.ip() == old_addr.addr()) {
                 self.addrs.remove(&old_addr);
                 self.queue.push_back(IfEvent::Down(old_addr));
             }


### PR DESCRIPTION
Reverse the logic when checking if a recorded interface still exists in the new list to avoid reporting all interfaces as down and then up in the same resync().

Tested on Android, which uses the fallback code.